### PR TITLE
setup-environment: fix setting custom OSTree commit message

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -155,7 +155,7 @@ build_ostree_repo() {
     --build-arg OSTREE_MANIFEST="$OSTREE_MANIFEST" \
     --build-arg OSTREE_ROOTFS="$OSTREE_ROOTFS" \
     --build-arg OSTREE_UPDATE_SUMMARY="$OSTREE_SUMMARY" \
-    --build-arg $OSTREE_COMMIT_MSG_BUILD_ARG ||
+    --build-arg "$OSTREE_COMMIT_MSG_BUILD_ARG" ||
     return
 
   # TODO: the $OSTREE_REPO dir is needed for next build to keep


### PR DESCRIPTION
This fixes the following build error when OSTree commit message is set:

```sh
INFO: Starting rpi3 OSTree repo build...
DEBUG: OSTree commit message: "Added custom compose apps" ERROR: "docker buildx build" requires exactly 1 argument. See 'docker buildx build --help'.
Usage:  docker buildx build [OPTIONS] PATH | URL | - Start a build
Error: Process completed with exit code 1.
```