### PR TITLE
setup-environment: fix using $ZSH_VERSION variable

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -1,6 +1,6 @@
 # vim: set ft=sh:
 set -o pipefail
-[ -n "$ZSH_VERSION" ] && setopt nullglob shwordsplit
+[ -n "$ZSH_VERSION" ] && setopt nullglob shwordsplit || true
 
 RED="\\e[31m"
 YELLOW="\\e[33m"


### PR DESCRIPTION
Don't exit with error if this variable is not available.